### PR TITLE
Handle symlinks in MLSD/MLST and LIST

### DIFF
--- a/file_system.go
+++ b/file_system.go
@@ -336,8 +336,11 @@ func parseLIST(entry string, loc *time.Location, skipSelfParent bool) (os.FileIn
 	}
 
 	var mode os.FileMode
-	if matches[1] == "d" {
+	switch matches[1] {
+	case "d":
 		mode |= os.ModeDir
+	case "l":
+		mode |= os.ModeSymlink
 	}
 
 	for i := 0; i < 3; i++ {
@@ -400,7 +403,7 @@ func parseMLST(entry string, skipSelfParent bool) (os.FileInfo, error) {
 
 	facts := make(map[string]string)
 	for _, factPair := range strings.Split(parts[0], ";") {
-		factParts := strings.Split(factPair, "=")
+		factParts := strings.SplitN(factPair, "=", 2)
 		if len(factParts) != 2 {
 			return nil, parseError
 		}
@@ -446,6 +449,9 @@ func parseMLST(entry string, skipSelfParent bool) (os.FileInfo, error) {
 
 	if typ == "dir" || typ == "cdir" || typ == "pdir" {
 		mode |= os.ModeDir
+	} else if strings.HasPrefix(typ, "os.unix=slink") || strings.HasPrefix(typ, "os.unix=symlink") {
+		// note: there is no general way to determine whether a symlink points to a dir or a file
+		mode |= os.ModeSymlink
 	}
 
 	var (

--- a/file_system_test.go
+++ b/file_system_test.go
@@ -169,6 +169,26 @@ func TestParseMLST(t *testing.T) {
 				size:  1089207168,
 			},
 		},
+		{
+			// test "type=OS.unix=slink"
+			"type=OS.unix=slink:;size=32;modify=20140728100902;UNIX.mode=0777;UNIX.uid=647;UNIX.gid=649;unique=fd01g1220c04; access-logs",
+			&ftpFile{
+				name:  "access-logs",
+				mtime: mustParseTime(timeFormat, "20140728100902"),
+				mode:  os.FileMode(0777) | os.ModeSymlink,
+				size:  32,
+			},
+		},
+		{
+			// test "type=OS.unix=symlink"
+			"modify=20150928140340;perm=adfrw;size=6;type=OS.unix=symlink;unique=801U5AA227;UNIX.group=1000;UNIX.mode=0777;UNIX.owner=1000; slinkdir",
+			&ftpFile{
+				name:  "slinkdir",
+				mtime: mustParseTime(timeFormat, "20150928140340"),
+				mode:  os.FileMode(0777) | os.ModeSymlink,
+				size:  6,
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Handle type=OS.unix=slink and type=OS.unix=symlink in MLSD/MLST output,
and the 'l' file type flag in LIST (ls long format) output.