### PR TITLE
add data connection timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,8 +100,11 @@ type Config struct {
 	ConnectionsPerHost int
 
 	// Timeout for opening connections and sending control commands. Defaults
-	// to 5 seconds. Currently there is no timeout for data transfers.
+	// to 5 seconds.
 	Timeout time.Duration
+
+	// Timeout for data connections. Defaults to 5 minutes.
+	DataTimeout time.Duration
 
 	// TLS Config used for FTPS. If provided, it will be an error if the server
 	// does not support TLS. Both the control and data connection will use TLS.
@@ -169,6 +172,10 @@ func newClient(config Config, hosts []string) *Client {
 
 	if config.Timeout <= 0 {
 		config.Timeout = 5 * time.Second
+	}
+
+	if config.DataTimeout <= 0 {
+		config.DataTimeout = 5 * time.Minute
 	}
 
 	if config.User == "" {

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -350,16 +350,16 @@ PASV:
 
 type DataConn struct {
 	net.Conn
-	time.Duration
+	Timeout time.Duration
 }
 
 func (c *DataConn) Read(buf []byte) (int, error) {
-	c.Conn.SetDeadline(time.Now().Add(c.Duration))
+	c.Conn.SetReadDeadline(time.Now().Add(c.Timeout))
 	return c.Conn.Read(buf)
 }
 
 func (c *DataConn) Write(buf []byte) (int, error) {
-	c.Conn.SetDeadline(time.Now().Add(c.Duration))
+	c.Conn.SetWriteDeadline(time.Now().Add(c.Timeout))
 	return c.Conn.Write(buf)
 }
 
@@ -394,8 +394,8 @@ func (pconn *persistentConn) prepareDataConn() (func() (net.Conn, error), error)
 			}
 
 			pconn.dataConn = &DataConn{
-				Conn:     dc,
-				Duration: pconn.config.DataTimeout,
+				Conn:    dc,
+				Timeout: pconn.config.DataTimeout,
 			}
 			return pconn.dataConn, nil
 		}, nil
@@ -423,8 +423,8 @@ func (pconn *persistentConn) prepareDataConn() (func() (net.Conn, error), error)
 
 		return func() (net.Conn, error) {
 			pconn.dataConn = &DataConn{
-				Conn:     dc,
-				Duration: pconn.config.DataTimeout,
+				Conn:    dc,
+				Timeout: pconn.config.DataTimeout,
 			}
 			return pconn.dataConn, nil
 		}, nil

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -398,6 +398,8 @@ func (pconn *persistentConn) prepareDataConn() (func() (net.Conn, error), error)
 			return nil, ftpError{err: netErr, temporary: isTemporary}
 		}
 
+		dc.SetDeadline(time.Now().Add(pconn.config.DataTimeout))
+
 		if pconn.config.TLSConfig != nil {
 			pconn.debug("upgrading data connection to TLS")
 			dc = tls.Client(dc, pconn.config.TLSConfig)


### PR DESCRIPTION
Thanks for the golang ftp client implementation, during my testing i have seen that some data connections keep stuck in the following code snipped during network timeouts, scanner.Scan() locks forever,

	scanner := bufio.NewScanner(dc)
	scanner.Split(bufio.ScanLines)

	var res []string
	for scanner.Scan() {
		res = append(res, scanner.Text())
	}

This pull requests adds dataconnection timeout to the client.config object.
