### PR TITLE
Fix error wrapping issue.

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,10 +58,16 @@ func (e ftpError) Timeout() bool {
 }
 
 func (e ftpError) Code() int {
+	if fe, ok := e.err.(Error); ok {
+		return fe.Code()
+	}
 	return e.code
 }
 
 func (e ftpError) Message() string {
+	if fe, ok := e.err.(Error); ok {
+		return fe.Message()
+	}
 	return e.msg
 }
 


### PR DESCRIPTION
Sometimes the code wraps a lower level ftpError inside a higher level ftpError.
The lower level error typically has the actual ftp error code and message set
if applicable. The higher level error might wrap the lower level error and set
the temporary flag if it thinks the error is transient. However, this wrapping
made the higher level error no longer report the correct Code() and Message().
Fix by making the higher level error delegate Code() and Message() to wrapped
error, if the wrapped error is another goftp.Error.

Fixes #14 