### PR TITLE
several fixes and features (rfc3659)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ Pull requests or feature requests are welcome, but in the case of the former, yo
 ### Tests ###
 
 How to run tests (windows not supported):
+* do not use the "root" account, use an unprivileged user with write access to the root goftp directory
 * ```./build_test_server.sh``` from root goftp directory (this downloads and compiles pure-ftpd and proftpd)
 * ```go test``` from the root goftp directory

--- a/build_test_server.sh
+++ b/build_test_server.sh
@@ -84,7 +84,7 @@ VpOorURz8ETlfAA=
 -----END CERTIFICATE-----
 CERT
 
-curl -O http://download.pureftpd.org/pub/pure-ftpd/releases/obsolete/pure-ftpd-1.0.36.tar.gz
+curl -k -O https://download.pureftpd.org/pub/pure-ftpd/releases/obsolete/pure-ftpd-1.0.36.tar.gz
 tar -xzf pure-ftpd-1.0.36.tar.gz
 cd pure-ftpd-1.0.36
 

--- a/client.go
+++ b/client.go
@@ -425,7 +425,7 @@ func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err erro
 
         if pconn.hasFeature("UTF8") {
                 if err = pconn.setUnicode(); err != nil {
-                       goto Error
+			goto Error
                 }
         }
 

--- a/client.go
+++ b/client.go
@@ -423,6 +423,12 @@ func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err erro
     		}
 	}
 
+        if pconn.hasFeature("UTF8") {
+                if err = pconn.setUnicode(); err != nil {
+                       goto Error
+                }
+        }
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/client.go
+++ b/client.go
@@ -417,6 +417,12 @@ func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err erro
 		goto Error
 	}
 
+	if pconn.hasFeature("CLNT") {
+    		if err = pconn.setClient(); err != nil {
+    			goto Error
+    		}
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/client.go
+++ b/client.go
@@ -429,6 +429,12 @@ func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err erro
                 }
         }
 
+        if pconn.hasFeature("MLST") {
+                if err = pconn.setMLST(); err != nil {
+                        goto Error
+                }
+        }
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/file_system.go
+++ b/file_system.go
@@ -112,6 +112,27 @@ func (c *Client) Getwd() (string, error) {
 	return dir, nil
 }
 
+// Setwd changes the current working directory.
+func (c *Client) Setwd(path string) (error) {
+	pconn, err := c.getIdleConn()
+	if err != nil {
+		return err
+	}
+
+	defer c.returnConn(pconn)
+
+	code, msg, err := pconn.sendCommand("CWD %s", path)
+	if err != nil {
+		return err
+	}
+
+	if code != replyFileActionOkay {
+		return ftpError{code: code, msg: msg}
+	}
+
+	return nil
+}
+
 func commandNotSupporterdError(err error) bool {
 	respCode := err.(ftpError).Code()
 	return respCode == replyCommandSyntaxError || respCode == replyCommandNotImplemented

--- a/file_system.go
+++ b/file_system.go
@@ -148,7 +148,9 @@ func (c *Client) ReadDir(path string) ([]os.FileInfo, error) {
 		info, err := parser(entry, true)
 		if err != nil {
 			c.debug("error in ReadDir: %s", err)
-			return nil, err
+			if !strings.Contains(err.Error(), "incomplete") {
+				return nil, err
+			}
 		}
 
 		if info == nil {

--- a/file_system.go
+++ b/file_system.go
@@ -173,7 +173,7 @@ func (c *Client) ReadDir(path string) ([]os.FileInfo, error) {
 		parser = func(entry string, skipSelfParent bool) (os.FileInfo, error) {
 			return parseLIST(entry, c.config.ServerLocation, skipSelfParent)
 		}
-        }
+	}
 
 	var ret []os.FileInfo
 	for _, entry := range entries {

--- a/file_system.go
+++ b/file_system.go
@@ -400,7 +400,7 @@ func parseMLST(entry string, skipSelfParent bool) (os.FileInfo, error) {
 	parseError := ftpError{err: fmt.Errorf(`failed parsing MLST entry: %s`, entry)}
 	incompleteError := ftpError{err: fmt.Errorf(`MLST entry incomplete: %s`, entry)}
 
-	parts := strings.Split(entry, "; ")
+	parts := strings.SplitN(entry, "; ", 2)
 	if len(parts) != 2 {
 		return nil, parseError
 	}
@@ -420,7 +420,7 @@ func parseMLST(entry string, skipSelfParent bool) (os.FileInfo, error) {
 		return nil, incompleteError
 	}
 
-	if skipSelfParent && (typ == "cdir" || typ == "pdir" || typ == "." || typ == "..") {
+	if skipSelfParent && (typ == "cdir" || typ == "pdir" || typ == "." || typ == ".."|| parts[1] == "." || parts[1] == "..") {
 		return nil, nil
 	}
 

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -205,7 +205,7 @@ func (pconn *persistentConn) fetchFeatures() error {
 	}
 
 	for _, line := range strings.Split(msg, "\n") {
-		if line[0] == ' ' {
+		if len(line) > 0 && line[0] == ' ' {
 			parts := strings.SplitN(strings.TrimSpace(line), " ", 2)
 			if len(parts) == 1 {
 				pconn.features[strings.ToUpper(parts[0])] = ""

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -180,6 +180,17 @@ func (pconn *persistentConn) readResponse() (int, string, error) {
 			err:       fmt.Errorf("error reading response: %s", err),
 			temporary: true,
 		}
+	} else if code == replyConnectionClosed {
+		pconn.controlConn.SetReadDeadline(time.Now().Add(pconn.config.Timeout))
+		code, msg, err = pconn.reader.ReadResponse(0)
+		if err != nil {
+			pconn.broken = true
+			pconn.debug("error reading second response: %s", err)
+			err = ftpError{
+				err:       fmt.Errorf("error reading response: %s", err),
+				temporary: true,
+			}
+		}
 	}
 	return code, msg, err
 }

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -63,6 +63,9 @@ type persistentConn struct {
 	// remember EPSV support
 	epsvNotSupported bool
 
+	// remember MLSD support	
+	mlsdNotSupported bool
+
 	// tracks the current type (e.g. ASCII/Image) of connection
 	currentType string
 

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -242,6 +242,20 @@ func (pconn *persistentConn) setClient() error {
         return nil
 }
 
+func (pconn *persistentConn) setUnicode() error {
+        code, msg, err := pconn.sendCommand("OPTS UTF8 ON")
+        if err != nil {
+                return err
+        }
+
+        if !positiveCompletionReply(code) {
+                pconn.debug("server doesn't support UTF8: %d-%s", code, msg)
+                return nil
+        }
+
+        return nil
+}
+
 func (pconn *persistentConn) logIn() error {
 	if pconn.config.User == "" {
 		return nil

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -228,6 +228,20 @@ func (pconn *persistentConn) hasFeatureWithArg(name, arg string) bool {
 	return found && strings.ToUpper(arg) == val
 }
 
+func (pconn *persistentConn) setClient() error {
+        code, msg, err := pconn.sendCommand("CLNT GoFTP")
+        if err != nil {
+                return err
+        }
+
+        if !positiveCompletionReply(code) {
+                pconn.debug("server doesn't support CLNT: %d-%s", code, msg)
+                return nil
+        }
+
+        return nil
+}
+
 func (pconn *persistentConn) logIn() error {
 	if pconn.config.User == "" {
 		return nil

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -256,6 +256,20 @@ func (pconn *persistentConn) setUnicode() error {
         return nil
 }
 
+func (pconn *persistentConn) setMLST() error {
+        code, msg, err := pconn.sendCommand("OPTS MLST type;size;modify;perm;unix.mode;")
+        if err != nil {
+                return err
+        }
+
+        if !positiveCompletionReply(code) {
+                pconn.debug("server doesn't support UTF8: %d-%s", code, msg)
+                return nil
+        }
+
+        return nil
+}
+
 func (pconn *persistentConn) logIn() error {
 	if pconn.config.User == "" {
 		return nil


### PR DESCRIPTION
* UTF8 proper support activation
* MLST facts configuration (don't count on server defaults)
* LIST DOS/Windows "dir"-style response processing
* CWD command support (required instead of LIST/MLST path argument on some servers)
* several fixes

changes tested on about 200 anonymous ftp servers