### PR TITLE
Add a DisableEPSV configuration option.

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,6 +144,11 @@ type Config struct {
 	// ":0", i.e. listen on the local control connection host and a random port.
 	ActiveListenAddr string
 
+	// Disables EPSV in favour of PASV. This is useful in cases where EPSV connections
+	// neither complete nor downgrade to PASV successfully by themselves, resulting in
+	// hung connections.
+	DisableEPSV bool
+
 	// For testing convenience.
 	stubResponses map[string]stubResponse
 }
@@ -353,12 +358,13 @@ func (c *Client) OpenRawConn() (RawConn, error) {
 // Open and set up a control connection.
 func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err error) {
 	pconn = &persistentConn{
-		idx:         idx,
-		features:    make(map[string]string),
-		config:      c.config,
-		t0:          c.t0,
-		currentType: "A",
-		host:        host,
+		idx:              idx,
+		features:         make(map[string]string),
+		config:           c.config,
+		t0:               c.t0,
+		currentType:      "A",
+		host:             host,
+		epsvNotSupported: c.config.DisableEPSV,
 	}
 
 	var conn net.Conn


### PR DESCRIPTION
This is to deal with cases where PASV requests lead to a successful connection
but EPSV requests to do not, possibly because of server-side configuration, IPv6,
NAT or firewall issues.

The DisableEPSV option is added in the spirit of the ftp:prefer-epsv option
provided by LFTP for similar reasons.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>