### PR TITLE
Bugfix around file listing with "LIST" (when "MLST" is not supported)

### DIFF
--- a/file_system.go
+++ b/file_system.go
@@ -175,7 +175,8 @@ func (c *Client) Stat(path string) (os.FileInfo, error) {
 				return nil, err
 			}
 
-			if len(lines) != 1 {
+			// The last file listing entry has a EOL even if there's only one file being listed.
+			if len(lines) != 2 || lines[1] != "" {
 				return nil, ftpError{err: fmt.Errorf("unexpected LIST response: %v", lines)}
 			}
 


### PR DESCRIPTION
I'm not sure how to add tests for it because that requires to have a server that doesn't support MLST.

I tested it with a FTP server library that I'm working on ( https://github.com/fclairamb/ftpserver ) and that works fine.

I do intend to support MLST by the way...