### PR TITLE
Send security commands if TLS config available

### DIFF
--- a/client.go
+++ b/client.go
@@ -413,6 +413,12 @@ func (c *Client) openConn(idx int, host string) (pconn *persistentConn, err erro
 		err = pconn.logInTLS()
 	} else {
 		err = pconn.logIn()
+		if err != nil {
+			goto Error
+		}
+		if c.config.TLSConfig != nil {
+			err = pconn.requireTLSDataConnection()
+		}
 	}
 
 	if err != nil {

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -504,6 +504,19 @@ func (pconn *persistentConn) setType(t string) error {
 	return err
 }
 
+func (pconn *persistentConn) requireTLSDataConnection() error {
+	err := pconn.sendCommandExpected(replyGroupPositiveCompletion, "PBSZ 0")
+	if err != nil {
+		return err
+	}
+
+	err = pconn.sendCommandExpected(replyGroupPositiveCompletion, "PROT P")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (pconn *persistentConn) logInTLS() error {
 	err := pconn.sendCommandExpected(replyAuthOkayNoDataNeeded, "AUTH TLS")
 	if err != nil {
@@ -516,13 +529,7 @@ func (pconn *persistentConn) logInTLS() error {
 	if err != nil {
 		return err
 	}
-
-	err = pconn.sendCommandExpected(replyGroupPositiveCompletion, "PBSZ 0")
-	if err != nil {
-		return err
-	}
-
-	err = pconn.sendCommandExpected(replyGroupPositiveCompletion, "PROT P")
+	err = pconn.requireTLSDataConnection()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Took me awhile to figure this one out, but if you have an Implicit FTPS connection, data connections are not secure unless you send the `PBSZ` and `PROT` commands first. This may be specific to a FTP server I'm dealing with (not sure what version or software), but it also seems to be part of the RFC here:

https://tools.ietf.org/html/rfc4217#section-9

