### PR TITLE
fix panic when empty line in FEAT response

### DIFF
--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -205,7 +205,7 @@ func (pconn *persistentConn) fetchFeatures() error {
 	}
 
 	for _, line := range strings.Split(msg, "\n") {
-		if line[0] == ' ' {
+		if len(line) > 0 && line[0] == ' ' {
 			parts := strings.SplitN(strings.TrimSpace(line), " ", 2)
 			if len(parts) == 1 {
 				pconn.features[strings.ToUpper(parts[0])] = ""

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -410,3 +410,23 @@ func TestResumeStoreOnWriteError(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyLinesFeat(t *testing.T) {
+	for _, addr := range ftpdAddrs {
+		c, err := DialConfig(goftpConfig, addr)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c.config.stubResponses = map[string]stubResponse{
+			"FEAT": {code: 211, msg: "Extensions supported:\n EPRT\n EPSV\n\nEND"},
+		}
+
+		// stat the file so the client asks for features
+		_, err = c.Stat("subdir/1234.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This is a cherry-pick of another PR that was not followed up on: https://github.com/secsy/goftp/pull/19/commits/86961aef897e1ef547741c6c60928797b39803b0 

Tested with a server that returns an empty line on FEAT command: https://github.com/goftp/server