### PR TITLE
Add ListParser as a config option

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"time"
 )
@@ -148,6 +149,12 @@ type Config struct {
 	// neither complete nor downgrade to PASV successfully by themselves, resulting in
 	// hung connections.
 	DisableEPSV bool
+
+	// Provide a custom parser for the outcome of the LIST command
+	// If this is not set, a default LIST parser is used that will handle most outcomes
+	ListParser interface {
+		ParseLIST(entry string) (os.FileInfo, error)
+	}
 
 	// For testing convenience.
 	stubResponses map[string]stubResponse

--- a/file_system.go
+++ b/file_system.go
@@ -139,6 +139,9 @@ func (c *Client) ReadDir(path string) ([]os.FileInfo, error) {
 			return nil, err
 		}
 		parser = func(entry string, skipSelfParent bool) (os.FileInfo, error) {
+			if c.config.ListParser != nil {
+				return c.config.ListParser.ParseLIST(entry)
+			}
 			return parseLIST(entry, c.config.ServerLocation, skipSelfParent)
 		}
 	}
@@ -179,6 +182,9 @@ func (c *Client) Stat(path string) (os.FileInfo, error) {
 				return nil, ftpError{err: fmt.Errorf("unexpected LIST response: %v", lines)}
 			}
 
+			if c.config.ListParser != nil {
+				return c.config.ListParser.ParseLIST(lines[0])
+			}
 			return parseLIST(lines[0], c.config.ServerLocation, false)
 		}
 		return nil, err


### PR DESCRIPTION
I've encountered some cases where the default parseLIST function fails to parse the outcome of a LIST command, despite getting useful data. This was encountered while communicating with an older FTP server.

Rather than attempting to cover all the types of output an FTP server could give in response to a LIST command, I've added the ability to specify a custom ListParser to handle these cases.

Here's a sample format i've seen that could not be handled, with fake fields:
`OWNER          777 11/12/13 01:02:03 TYPE      /some/directory/file.txt`