### PR TITLE
fix TLS for active connections

### DIFF
--- a/build_test_server.sh
+++ b/build_test_server.sh
@@ -7,9 +7,9 @@ cd ftpd
 
 ftpd_dir=`pwd`
 
-curl -O ftp://ftp.proftpd.org/distrib/source/proftpd-1.3.5.tar.gz
-tar -xzf proftpd-1.3.5.tar.gz
-cd proftpd-1.3.5
+curl -L -O https://github.com/proftpd/proftpd/archive/v1.3.5e.tar.gz 
+tar -xzf v1.3.5e.tar.gz 
+cd proftpd-1.3.5e
 
 # fix slow tls data connection handshake (https://github.com/proftpd/proftpd/pull/48)
 perl -pi -e 's/(\Qpr_inet_set_proto_nodelay(conn->pool, conn, 1);\E)/$1\n(void) pr_inet_set_proto_cork(conn->wfd, 0);/' contrib/mod_tls.c

--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -402,7 +402,10 @@ func (pconn *persistentConn) prepareDataConn() (func() (net.Conn, error), error)
 			}
 
 			if pconn.config.TLSConfig != nil {
-				dc = tls.Server(dc, pconn.config.TLSConfig)
+				// based on RFC 4217, section 7, for active connections
+				// the FTP client MUST be the TLS client and the FTP
+				// server MUST be the TLS server
+				dc = tls.Client(dc, pconn.config.TLSConfig)
 				pconn.debug("upgraded active connection to TLS")
 			}
 


### PR DESCRIPTION
based on RFC 4217, section 7, for active connections the FTP client MUST
be the TLS client and the FTP server MUST be the TLS server