### PR TITLE
Fallback to server IP if PASV IP is unrouteable

### DIFF
--- a/persistent_connection.go
+++ b/persistent_connection.go
@@ -7,6 +7,7 @@ package goftp
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/textproto"
@@ -345,7 +346,39 @@ PASV:
 		port |= portOctet << (byte(1-i) * 8)
 	}
 
+	pconn.debug("check returned IP routable: %s", ip.String())
+	isRoutable, err := isRoutableIP(ip.String())
+	if err != nil {
+		pconn.debug("failed to resolve whether IP %v is routable: %s", ip.String(), err)
+	}
+	if !isRoutable {
+		pconn.debug("returned IP %v is not routable, use server address instead", ip.String())
+
+		remoteHost, _, err = net.SplitHostPort(pconn.controlConn.RemoteAddr().String())
+		if err != nil {
+			pconn.debug("failed determining remote host: %s", err)
+
+		} else {
+			return net.JoinHostPort(remoteHost, strconv.Itoa(port)), nil
+		}
+	}
+
 	return net.JoinHostPort(ip.String(), strconv.Itoa(port)), nil
+}
+
+func isRoutableIP(ip string) (bool, error) {
+	var err error
+	private := false
+	IP := net.ParseIP(ip)
+	if IP == nil {
+		err = errors.New("Invalid IP")
+	} else {
+		_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
+		_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
+		_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
+		private = private24BitBlock.Contains(IP) || private20BitBlock.Contains(IP) || private16BitBlock.Contains(IP)
+	}
+	return !private, err
 }
 
 type dataConn struct {
@@ -419,6 +452,11 @@ func (pconn *persistentConn) prepareDataConn() (func() (net.Conn, error), error)
 		if pconn.config.TLSConfig != nil {
 			pconn.debug("upgrading data connection to TLS")
 			dc = tls.Client(dc, pconn.config.TLSConfig)
+		}
+		if dc == nil {
+			pconn.debug("data connection lost after upgrade to TLS")
+		} else {
+			pconn.debug("connection available")
 		}
 
 		return func() (net.Conn, error) {


### PR DESCRIPTION
Extended PSV data connection dropped by FileZilla server because the session does not match the control connection. If IP returned in connection is not routeable then use server IP instead.

Client log:
goftp: 0.000 #1 opening control connection to xxx.xxx.xxx.xxx:yyyyy
goftp: 0.138 #1 sending command AUTH TLS
goftp: 0.208 #1 got 234-Using authentication type TLS
goftp: 0.208 #1 sending command USER username
goftp: 0.609 #1 got 331-Password required for username
goftp: 0.609 #1 sending command PASS ******
goftp: 0.678 #1 got 230-Logged on
goftp: 0.678 #1 sending command PBSZ 0
goftp: 0.746 #1 got 200-PBSZ=0
goftp: 0.746 #1 sending command PROT P
goftp: 0.814 #1 got 200-Protection level set to P
goftp: 0.814 #1 successfully upgraded to TLS
goftp: 0.814 #1 sending command FEAT
goftp: 0.883 #1 got 211-Features:
 MDTM
 REST STREAM
 SIZE
 MLST type*;size*;modify*;
 MLSD
 AUTH SSL
 AUTH TLS
 PROT
 PBSZ
 UTF8
 CLNT
 MFMT
 EPSV
 EPRT
End
goftp: 0.883 #1 sending command PWD
goftp: 0.951 #1 got 257-"/" is current directory.
goftp: 0.953 #1 was ready
goftp: 0.953 #1 was ready
goftp: 0.953 #1 sending command TYPE I
goftp: 1.021 #1 got 200-Type set to I
goftp: 1.021 #1 sending command EPSV
goftp: 1.090 #1 got 229-Entering Extended Passive Mode (|||yyyyy|)
goftp: 1.090 #1 opening data connection to [xxx.xxx.xxx.xxx]:yyyyy
goftp: 1.160 #1 upgrading data connection to TLS
goftp: 1.160 #1 connection available
goftp: 1.160 #1 sending command STOR vidname.avi
goftp: 1.230 #1 got 150-Opening data channel for file upload to server of "/vidname.avi"
goftp: 1.534 #1 error copying data: EOF
goftp: 1.534 #1 closing

Server log:
Fillezilla Server 0.9.60.2 on Windows Server 2012R2.
(000033) 11/10/2019 10:32:32 - (not logged in) (xxx.xxx.xxx.xxx)> Connected on port yyyyy, sending welcome message...
(000033) 11/10/2019 10:32:32 - (not logged in) (xxx.xxx.xxx.xxx)> 220 My Name
(000033) 11/10/2019 10:32:32 - (not logged in) (xxx.xxx.xxx.xxx)> AUTH TLS
(000033) 11/10/2019 10:32:32 - (not logged in) (xxx.xxx.xxx.xxx)> 234 Using authentication type TLS
(000033) 11/10/2019 10:32:33 - (not logged in) (xxx.xxx.xxx.xxx)> TLS connection established
(000033) 11/10/2019 10:32:33 - (not logged in) (xxx.xxx.xxx.xxx)> USER username
(000033) 11/10/2019 10:32:33 - (not logged in) (xxx.xxx.xxx.xxx)> 331 Password required for username
(000033) 11/10/2019 10:32:33 - (not logged in) (xxx.xxx.xxx.xxx)> PASS ********
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 230 Logged on
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> PBSZ 0
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 200 PBSZ=0
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> PROT P
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 200 Protection level set to P
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> FEAT
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 211-Features:
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  MDTM
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  REST STREAM
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  SIZE
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  MLST type*;size*;modify*;
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  MLSD
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  AUTH SSL
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  AUTH TLS
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  PROT
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  PBSZ
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  UTF8
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  CLNT
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  MFMT
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  EPSV
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)>  EPRT
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 211 End
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> PWD
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 257 "/" is current directory.
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> TYPE I
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 200 Type set to I
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> EPSV
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 229 Entering Extended Passive Mode (|||yyyyy|)
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> STOR vidname.avi
(000033) 11/10/2019 10:32:33 - username (xxx.xxx.xxx.xxx)> 150 Opening data channel for file upload to server of "/vidname.avi"
(000033) 11/10/2019 10:32:34 - username (xxx.xxx.xxx.xxx)> 450 TLS session of data connection has not resumed or the session does not match the control connection
(000033) 11/10/2019 10:32:34 - username (xxx.xxx.xxx.xxx)> disconnected.