### PR TITLE
support connection health test via Noop 

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,6 +31,9 @@ type Error interface {
 	// Similarly, this will return the text response from the server, or empty
 	// string.
 	Message() string
+
+	// implement Unwrap interface
+	Unwrap() error
 }
 
 type ftpError struct {
@@ -69,6 +72,10 @@ func (e ftpError) Message() string {
 		return fe.Message()
 	}
 	return e.msg
+}
+
+func (e ftpError) Unwrap() error {
+	return e.err
 }
 
 // TLSMode represents the FTPS connection strategy. Servers cannot support
@@ -230,6 +237,15 @@ func (c *Client) Close() error {
 	}
 
 	return nil
+}
+
+func (c *Client) Noop() error {
+	pconn, err := c.getIdleConn()
+	if err != nil {
+		return err
+	}
+	defer c.returnConn(pconn)
+	return pconn.sendCommandExpected(replyCommandOkay, "NOOP")
 }
 
 // Log a debug message in the context of the client (i.e. not for a


### PR DESCRIPTION
I needed to test for connectivity after creating the client.  

### What was Added
1. added `func (c *Client) Noop() error` to test for connectivity (example below)
2. added `func (e ftpError) Unwrap() error` to support errors.Is, errors.As (go 1.13)

### Example Usage

```
if err := client.Noop(); err != nil {
		if errors.Is(err, syscall.ECONNREFUSED) {
			log.Fatalf("connection refused: %s", err)
		}
		log.Fatalf("unknown connection error: %s", err)
	}
	
```